### PR TITLE
CGV-2508: Stop the VPN Service gracefully when revoked

### DIFF
--- a/vpnmanager/vpnservicemanager/src/main/java/com/kape/vpnservicemanager/data/externals/IService.kt
+++ b/vpnmanager/vpnservicemanager/src/main/java/com/kape/vpnservicemanager/data/externals/IService.kt
@@ -34,6 +34,7 @@ internal interface IService {
         protocol: IProtocol,
         subnet: ISubnet,
         cache: ICache,
+        onServiceRevoked: () -> Unit,
     ): Result<Unit>
 
     /**

--- a/vpnmanager/vpnservicemanager/src/main/java/com/kape/vpnservicemanager/presenters/VPNServiceManagerBuilder.kt
+++ b/vpnmanager/vpnservicemanager/src/main/java/com/kape/vpnservicemanager/presenters/VPNServiceManagerBuilder.kt
@@ -181,6 +181,7 @@ public class VPNServiceManagerBuilder {
             )
         )
         val serviceConnection: IServiceConnection = ServiceConnection(
+            context = context,
             cache = cache,
             subnet = subnet,
             protocol = protocol,

--- a/vpnmanager/vpnservicemanager/src/test/java/com/kape/vpnservicemanager/testutils/GivenExternal.kt
+++ b/vpnmanager/vpnservicemanager/src/test/java/com/kape/vpnservicemanager/testutils/GivenExternal.kt
@@ -59,6 +59,7 @@ internal object GivenExternal {
         cache: ICache = cache(),
     ): IServiceConnection =
         ServiceConnection(
+            context = context,
             cache = cache,
             subnet = subnet,
             protocol = protocol,


### PR DESCRIPTION
In the current version of the VPN Manager library, if the VPN profile is revoked while connected or the user disconnects the VPN from Android settings, the VPN connection goes into an invalid state because it didn't have a change to stop gracefully.

This means the clients have not received proper status notifications about the VPN connectivity state and the users cannot also recover from this state because the library does not allow starting up a new VPN connection.

This PR fixes the issue by gracefully stopping the VPN connection whenever the VPN service receives a revoked callback.