### PR TITLE
PIA-1776: Avoid throwing when reporting bytecount details

### DIFF
--- a/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/usecases/wireguard/StartWireguardByteCountJob.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/usecases/wireguard/StartWireguardByteCountJob.kt
@@ -56,8 +56,12 @@ internal class StartWireguardByteCountJob(
 
     // region private
     private fun jobAction(tunnelHandle: Int) {
-        val configuration = wireguard.configuration(tunnelHandle = tunnelHandle).getOrThrow()
-        val (tx, rx) = getByteCountFromConfigurationOutput(output = configuration).getOrThrow()
+        val configuration = wireguard.configuration(tunnelHandle = tunnelHandle).getOrElse {
+            return
+        }
+        val (tx, rx) = getByteCountFromConfigurationOutput(output = configuration).getOrElse {
+            return
+        }
         cacheProtocol.reportByteCount(tx = tx, rx = rx)
     }
 


### PR DESCRIPTION
## Summary

I've tried to reproduce it under normal circumstances but failed to do so, so I've forced it by passing an invalid `tunnelhandle`. Regardless of this, we shouldn't be throwing within the byte count job as this is not a critical part of the system.

## Sanity Tests

- [x] While forcing the test scenario. Connect. Confirm we connect successfully. Confirm we don't receive byte count. Confirm we don't crash.