### PR TITLE
PIA-XXXX: Update connectivity logic to use tcp sockets

### DIFF
--- a/vpnmanager/vpnservicemanager/src/main/java/com/kape/vpnservicemanager/data/externals/Connectivity.kt
+++ b/vpnmanager/vpnservicemanager/src/main/java/com/kape/vpnservicemanager/data/externals/Connectivity.kt
@@ -1,9 +1,8 @@
 package com.kape.vpnservicemanager.data.externals
 
-import com.kape.vpnservicemanager.presenters.VPNServiceManagerError
-import com.kape.vpnservicemanager.presenters.VPNServiceManagerErrorCode
 import java.io.IOException
-import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Socket
 
 /*
  *  Copyright (c) 2022 Private Internet Access, Inc.
@@ -27,17 +26,17 @@ internal class Connectivity : IConnectivity {
 
     companion object {
         private const val PING_TIMEOUT = 3000
+        private const val PING_PORT = 443
     }
 
     // region IConnectivity
     override suspend fun isNetworkReachable(host: String): Result<Unit> {
         try {
-            val isReachable = InetAddress.getByName(host).isReachable(PING_TIMEOUT)
-            return if (isReachable) {
-                Result.success(Unit)
-            } else {
-                Result.failure(VPNServiceManagerError(code = VPNServiceManagerErrorCode.NETWORK_UNREACHABLE))
-            }
+            val socket = Socket()
+            socket.tcpNoDelay = true
+            socket.connect(InetSocketAddress(host, PING_PORT), PING_TIMEOUT)
+            socket.close()
+            return Result.success(Unit)
         } catch (exception: IOException) {
             return Result.failure(exception)
         }

--- a/vpnmanager/vpnservicemanager/src/test/java/com/kape/vpnservicemanager/data/externals/ConnectivityTest.kt
+++ b/vpnmanager/vpnservicemanager/src/test/java/com/kape/vpnservicemanager/data/externals/ConnectivityTest.kt
@@ -32,7 +32,7 @@ internal class ConnectivityTest {
     fun `local host is reachable`() = runTest {
         val connectivity = Connectivity()
 
-        val result = connectivity.isNetworkReachable("127.0.0.1")
+        val result = connectivity.isNetworkReachable("1.1.1.1")
 
         assert(result.isSuccess)
     }

--- a/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/data/externals/common/Connectivity.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/data/externals/common/Connectivity.kt
@@ -20,10 +20,9 @@
 
 package com.kape.vpnprotocol.data.externals.common
 
-import com.kape.vpnprotocol.presenters.VPNProtocolError
-import com.kape.vpnprotocol.presenters.VPNProtocolErrorCode
 import java.io.IOException
-import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Socket
 
 /*
  *  Copyright (c) 2022 Private Internet Access, Inc.
@@ -47,17 +46,17 @@ internal class Connectivity : IConnectivity {
 
     companion object {
         private const val PING_TIMEOUT = 3000
+        private const val PING_PORT = 443
     }
 
     // region IConnectivity
     override suspend fun isNetworkReachable(host: String): Result<Unit> {
         try {
-            val isReachable = InetAddress.getByName(host).isReachable(PING_TIMEOUT)
-            return if (isReachable) {
-                Result.success(Unit)
-            } else {
-                Result.failure(VPNProtocolError(code = VPNProtocolErrorCode.NETWORK_NOT_REACHABLE))
-            }
+            val socket = Socket()
+            socket.tcpNoDelay = true
+            socket.connect(InetSocketAddress(host, PING_PORT), PING_TIMEOUT)
+            socket.close()
+            return Result.success(Unit)
         } catch (exception: IOException) {
             return Result.failure(exception)
         }


### PR DESCRIPTION
## Summary

Update connectivity logic to use a tcp socket.

## Sanity Tests

- [x] Using the test app. Confirm it connects successfully.
- [x] Using the test app. Change the connectivity port. Confirm it fails to connect.