### PR TITLE
Km-15482: Fix out-of-order status change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Android VPN Manager is a modular Android SDK/library (AAR) that provides VPN capabilities for Android clients. It supports OpenVPN and WireGuard protocols and is published to GitHub Packages Maven repository as `com.kape.android:vpnmanager`.
+
+## Build Commands
+
+```bash
+# Build release AAR
+./gradlew clean vpnmanager:assemble
+
+# Run all tests
+./gradlew test --parallel
+
+# Run tests for a single module
+./gradlew :vpnmanager:test
+
+# Run a single test class
+./gradlew test --tests="*ClassName"
+
+# Lint check
+./gradlew ktlintCheck
+
+# Auto-format code
+./gradlew ktlintFormat
+
+# Publish to local Maven
+./gradlew publishMavenPublicationToMavenLocal
+```
+
+**Build outputs:**
+- AAR: `vpnmanager/build/outputs/aar/`
+- Test app APK: `testapp/build/outputs/apk/`
+
+**macOS requirement:** `flock` and `sha256sum` must be installed (`brew install flock coreutils`).
+
+## Module Architecture
+
+```
+:vpnmanager                         # Main aggregator + implementation
+├── :vpnmanager:vpnmanagerapi       # Public API interfaces and data models
+├── :vpnmanager:targetprovider      # Optimal server selection (latency-based)
+├── :vpnmanager:vpnservicemanager   # Android OS VPN service management
+│   └── :vpnservicemanager:vpnprotocol            # Protocol abstraction layer
+│       ├── :vpnprotocol:openvpn                  # Pure Kotlin OpenVPN impl
+│       └── :vpnprotocol:wireguard                # WireGuard (Go + CMake native)
+:testapp                            # Example Android application
+```
+
+## Key Architecture Patterns
+
+**Clean Architecture layers** (all modules follow this):
+`Presenters → Controllers → Use Cases → Data Sources / Externals`
+
+**Entry points:**
+- `VPNManagerBuilder` — Builder for initializing the SDK; client provides `Context`, permissions dependency, debug logging, and byte count callback
+- `VPNManagerAPI` — Main public interface; all client interaction goes through this
+
+**State management:**
+- Single source of truth via `Cache` datasource pattern (see `data/models/State.kt`)
+- `VPNManagerConnectionStatus` is a sealed class covering: `Connecting`, `Connected`, `Disconnecting`, `Disconnected`, `Error`, `Reconnecting`, and `Paused`
+
+**Async model:** Coroutines throughout; client-facing callbacks use `kotlin.Result<T>`. Two coroutine contexts exist — a module-internal context and a client-callback context.
+
+**Server iteration:** `StartConnectionController` iterates through the server list with fallback logic; `TargetProvider` runs latency checks to select the optimal server before connecting.
+
+**Protocol selection:** The `vpnprotocol` layer is protocol-agnostic; the concrete OpenVPN/WireGuard implementations are injected. WireGuard uses a native Go library built via CMake.
+
+## Important Models
+
+| File | Purpose |
+|---|---|
+| `vpnmanagerapi/.../VPNManagerAPI.kt` | Public interface |
+| `vpnmanagerapi/.../VPNManagerConnectionStatus.kt` | Connection state machine |
+| `vpnmanager/.../data/models/ServerList.kt` | Server definitions (IP, port, transport, ciphers, DNS) |
+| `vpnmanager/.../data/models/State.kt` | Internal state (single source of truth) |
+
+## Toolchain
+
+- Kotlin 2.2.0, AGP 8.11.1, Java 17
+- Min SDK 21, Target/Compile SDK 34
+- Ktor 3.2.1 (HTTP), Kotlin Serialization 1.9.0, Spongy Castle (crypto)
+- Tests: JUnit 4, Robolectric 4.10.3, MockK 1.13.9, kotlinx-coroutines-test
+- Ktlint 11.5.1 with trailing commas enabled (`.editorconfig`)
+
+## CI/CD
+
+Four GitHub Actions workflows in `.github/workflows/`:
+- `lint-android.yaml` — ktlintCheck
+- `test-android.yaml` — `./gradlew test`
+- `build-android.yaml` — builds APK and AAR
+- `push.yaml` — orchestrates all three on push
+
+## Publishing
+
+Artifacts publish to `https://maven.pkg.github.com/pia-foss/mobile-android-vpn-manager/`. Requires environment variables `GITHUB_USERNAME` and `GITHUB_TOKEN`.

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.library' version '8.11.1' apply false
+    id 'com.android.library' version '9.1.1' apply false
     id 'org.jetbrains.kotlin.android' version "$kotlinVersion" apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version "$kotlinVersion"
     id 'org.jlleitschuh.gradle.ktlint' version "11.5.1"

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,13 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.resvalues=true
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Mar 03 14:09:46 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/vpnmanager/build.gradle
+++ b/vpnmanager/build.gradle
@@ -8,7 +8,6 @@ android {
 
     defaultConfig {
         minSdk rootProject.minSdkVersion
-        targetSdk rootProject.targetSdkVersion
     }
 
     compileOptions {
@@ -29,8 +28,12 @@ android {
         unitTests {
             includeAndroidResources = true
         }
+        targetSdk 34
     }
     namespace 'com.kape.vpnmanager'
+    lint {
+        targetSdk 34
+    }
 }
 
 dependencies {

--- a/vpnmanager/targetprovider/build.gradle
+++ b/vpnmanager/targetprovider/build.gradle
@@ -8,7 +8,6 @@ android {
 
     defaultConfig {
         minSdk rootProject.minSdkVersion
-        targetSdk rootProject.targetSdkVersion
     }
 
     compileOptions {
@@ -27,6 +26,12 @@ android {
         }
     }
     namespace 'com.kape.targetprovider'
+    lint {
+        targetSdk 34
+    }
+    testOptions {
+        targetSdk 34
+    }
 }
 
 dependencies {

--- a/vpnmanager/vpnmanagerapi/build.gradle
+++ b/vpnmanager/vpnmanagerapi/build.gradle
@@ -8,7 +8,6 @@ android {
 
     defaultConfig {
         minSdk rootProject.minSdkVersion
-        targetSdk rootProject.targetSdkVersion
     }
 
     compileOptions {
@@ -27,6 +26,12 @@ android {
         }
     }
     namespace 'com.kape.vpnmanagerapi'
+    lint {
+        targetSdk 34
+    }
+    testOptions {
+        targetSdk 34
+    }
 }
 
 dependencies {

--- a/vpnmanager/vpnservicemanager/build.gradle
+++ b/vpnmanager/vpnservicemanager/build.gradle
@@ -8,7 +8,6 @@ android {
 
     defaultConfig {
         minSdk rootProject.minSdkVersion
-        targetSdk rootProject.targetSdkVersion
     }
 
     compileOptions {
@@ -27,6 +26,12 @@ android {
         }
     }
     namespace 'com.kape.vpnservicemanager'
+    lint {
+        targetSdk 34
+    }
+    testOptions {
+        targetSdk 34
+    }
 }
 
 dependencies {

--- a/vpnmanager/vpnservicemanager/vpnprotocol/build.gradle
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/build.gradle
@@ -9,7 +9,6 @@ android {
 
     defaultConfig {
         minSdk rootProject.minSdkVersion
-        targetSdk rootProject.targetSdkVersion
     }
 
     compileOptions {
@@ -28,6 +27,12 @@ android {
         }
     }
     namespace 'com.kape.vpnprotocol'
+    lint {
+        targetSdk 34
+    }
+    testOptions {
+        targetSdk 34
+    }
 }
 
 dependencies {

--- a/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/build.gradle
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/build.gradle
@@ -8,7 +8,6 @@ android {
 
     defaultConfig {
         minSdk rootProject.minSdkVersion
-        targetSdk rootProject.targetSdkVersion
         ndk.abiFilters 'armeabi-v7a','arm64-v8a','x86','x86_64'
     }
 
@@ -30,6 +29,12 @@ android {
         }
     }
     namespace 'com.kape.openvpn'
+    lint {
+        targetSdk 34
+    }
+    testOptions {
+        targetSdk 34
+    }
 }
 
 dependencies {

--- a/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/openvpn/StartOpenVpnConnectionController.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/openvpn/StartOpenVpnConnectionController.kt
@@ -194,8 +194,18 @@ internal class StartOpenVpnConnectionController(
     }
     // endregion
 
+    // Note: we intentionally do NOT report VPNManagerConnectionStatus.Disconnected here.
+    // The outer StartConnectionController (in vpnservicemanager) catches this throw and
+    // calls stopConnection(...) on the failure path, which routes through
+    // Stop{Wireguard,OpenVpn}ConnectionController and emits the canonical
+    // Disconnecting -> Disconnected(disconnectReason) sequence. Emitting Disconnected
+    // here would cause a redundant Disconnected -> Disconnecting -> Disconnected flap
+    // for clients observing handleConnectionStatusChange(...).
+    // The `disconnectReason` parameter is kept on the signature so each call site still
+    // documents the failure category; it is not used now but the outer cleanup will
+    // supply its own DisconnectReason when invoking stopConnection.
+    @Suppress("UNUSED_PARAMETER")
     private suspend fun handleFailure(throwable: Throwable, disconnectReason: DisconnectReason) {
-        reportConnectivityStatus(connectivityStatus = VPNManagerConnectionStatus.Disconnected(disconnectReason))
         clearCache()
         throw throwable
     }

--- a/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/openvpn/StopOpenVpnConnectionController.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/openvpn/StopOpenVpnConnectionController.kt
@@ -56,12 +56,11 @@ internal class StopOpenVpnConnectionController(
         // the StartConnectionController failure path before the OpenVPN process was ever
         // started. Regardless of cleanup outcome we must still report the canonical
         // Disconnecting -> Disconnected sequence so clients always see a terminal state.
-        val cleanupResult = reportConnectivityStatus(
+        val result = reportConnectivityStatus(
             connectivityStatus = VPNManagerConnectionStatus.Disconnecting
-        )
-            .mapCatching {
-                stopOpenVpnProcess().getOrThrow()
-            }
+        ).mapCatching {
+            stopOpenVpnProcess().getOrThrow()
+        }
 
         // Always emit Disconnected, even if the cleanup chain failed.
         reportConnectivityStatus(
@@ -72,7 +71,7 @@ internal class StopOpenVpnConnectionController(
         // the result; if cleanup already failed, propagate the original cleanup failure
         // and ignore any clearCache() error (best-effort).
         val clearResult = clearCache()
-        return cleanupResult.fold(
+        return result.fold(
             onSuccess = { clearResult },
             onFailure = { Result.failure(it) }
         )

--- a/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/openvpn/StopOpenVpnConnectionController.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/openvpn/StopOpenVpnConnectionController.kt
@@ -52,27 +52,29 @@ internal class StopOpenVpnConnectionController(
 
     // region IStopOpenVpnConnectionController
     override suspend fun invoke(disconnectReason: DisconnectReason): Result<Unit> {
-        val result = reportConnectivityStatus(connectivityStatus = VPNManagerConnectionStatus.Disconnecting)
+        // Best-effort cleanup. stopOpenVpnProcess() may fail when stop is invoked from
+        // the StartConnectionController failure path before the OpenVPN process was ever
+        // started. Regardless of cleanup outcome we must still report the canonical
+        // Disconnecting -> Disconnected sequence so clients always see a terminal state.
+        val cleanupResult = reportConnectivityStatus(
+            connectivityStatus = VPNManagerConnectionStatus.Disconnecting
+        )
             .mapCatching {
                 stopOpenVpnProcess().getOrThrow()
             }
-            .mapCatching {
-                reportConnectivityStatus(
-                    connectivityStatus = VPNManagerConnectionStatus.Disconnected(disconnectReason)
-                ).getOrThrow()
-            }
-            .mapCatching {
-                clearCache().getOrThrow()
-            }
 
-        return result.fold(
-            onSuccess = {
-                Result.success(it)
-            },
-            onFailure = {
-                clearCache()
-                Result.failure(it)
-            }
+        // Always emit Disconnected, even if the cleanup chain failed.
+        reportConnectivityStatus(
+            connectivityStatus = VPNManagerConnectionStatus.Disconnected(disconnectReason)
+        )
+
+        // Always clear cache. If cleanup succeeded, surface a clearCache() failure as
+        // the result; if cleanup already failed, propagate the original cleanup failure
+        // and ignore any clearCache() error (best-effort).
+        val clearResult = clearCache()
+        return cleanupResult.fold(
+            onSuccess = { clearResult },
+            onFailure = { Result.failure(it) }
         )
     }
     // endregion

--- a/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/openvpn/StopOpenVpnConnectionController.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/openvpn/StopOpenVpnConnectionController.kt
@@ -52,28 +52,30 @@ internal class StopOpenVpnConnectionController(
 
     // region IStopOpenVpnConnectionController
     override suspend fun invoke(disconnectReason: DisconnectReason): Result<Unit> {
-        // Best-effort cleanup. stopOpenVpnProcess() may fail when stop is invoked from
-        // the StartConnectionController failure path before the OpenVPN process was ever
-        // started. Regardless of cleanup outcome we must still report the canonical
-        // Disconnecting -> Disconnected sequence so clients always see a terminal state.
-        val result = reportConnectivityStatus(
-            connectivityStatus = VPNManagerConnectionStatus.Disconnecting
-        ).mapCatching {
-            stopOpenVpnProcess().getOrThrow()
-        }
+        val result = reportConnectivityStatus(connectivityStatus = VPNManagerConnectionStatus.Disconnecting)
+            .mapCatching {
+                stopOpenVpnProcess().getOrThrow()
+            }
+            .mapCatching {
+                reportConnectivityStatus(
+                    connectivityStatus = VPNManagerConnectionStatus.Disconnected(disconnectReason)
+                ).getOrThrow()
+            }
+            .mapCatching {
+                clearCache().getOrThrow()
+            }
 
-        // Always emit Disconnected, even if the cleanup chain failed.
-        reportConnectivityStatus(
-            connectivityStatus = VPNManagerConnectionStatus.Disconnected(disconnectReason)
-        )
-
-        // Always clear cache. If cleanup succeeded, surface a clearCache() failure as
-        // the result; if cleanup already failed, propagate the original cleanup failure
-        // and ignore any clearCache() error (best-effort).
-        val clearResult = clearCache()
         return result.fold(
-            onSuccess = { clearResult },
-            onFailure = { Result.failure(it) }
+            onSuccess = {
+                Result.success(it)
+            },
+            onFailure = {
+                reportConnectivityStatus(
+                    connectivityStatus = VPNManagerConnectionStatus.Disconnected(disconnectReason)
+                )
+                clearCache()
+                Result.failure(it)
+            }
         )
     }
     // endregion

--- a/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/wireguard/StartWireguardConnectionController.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/wireguard/StartWireguardConnectionController.kt
@@ -197,8 +197,18 @@ internal class StartWireguardConnectionController(
     }
     // endregion
 
+    // Note: we intentionally do NOT report VPNManagerConnectionStatus.Disconnected here.
+    // The outer StartConnectionController (in vpnservicemanager) catches this throw and
+    // calls stopConnection(...) on the failure path, which routes through
+    // Stop{Wireguard,OpenVpn}ConnectionController and emits the canonical
+    // Disconnecting -> Disconnected(disconnectReason) sequence. Emitting Disconnected
+    // here would cause a redundant Disconnected -> Disconnecting -> Disconnected flap
+    // for clients observing handleConnectionStatusChange(...).
+    // The `disconnectReason` parameter is kept on the signature so each call site still
+    // documents the failure category; it is not used now but the outer cleanup will
+    // supply its own DisconnectReason when invoking stopConnection.
+    @Suppress("UNUSED_PARAMETER")
     private suspend fun handleFailure(throwable: Throwable, disconnectReason: DisconnectReason) {
-        reportConnectivityStatus(connectivityStatus = VPNManagerConnectionStatus.Disconnected(disconnectReason))
         clearCache()
         throw throwable
     }

--- a/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/wireguard/StopWireguardConnectionController.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/wireguard/StopWireguardConnectionController.kt
@@ -56,7 +56,15 @@ internal class StopWireguardConnectionController(
 
     // region IStopWireguardConnectionController
     override suspend fun invoke(disconnectReason: DisconnectReason): Result<Unit> {
-        val result = reportConnectivityStatus(connectivityStatus = VPNManagerConnectionStatus.Disconnecting)
+        // Best-effort cleanup chain. Any step here may legitimately fail (e.g. when stop
+        // is invoked from the StartConnectionController failure path before a tunnel was
+        // ever created — there will be no byte count job and no tunnel handle to look
+        // up). We must still report the canonical Disconnecting -> Disconnected sequence
+        // regardless of cleanup outcome so clients observing
+        // handleConnectionStatusChange(...) always see a terminal state.
+        val cleanupResult = reportConnectivityStatus(
+            connectivityStatus = VPNManagerConnectionStatus.Disconnecting
+        )
             .mapCatching {
                 stopWireguardByteCountJob().getOrThrow()
             }
@@ -66,23 +74,19 @@ internal class StopWireguardConnectionController(
             .mapCatching {
                 destroyWireguardTunnel(tunnelHandle = it).getOrThrow()
             }
-            .mapCatching {
-                reportConnectivityStatus(
-                    connectivityStatus = VPNManagerConnectionStatus.Disconnected(disconnectReason)
-                ).getOrThrow()
-            }
-            .mapCatching {
-                clearCache().getOrThrow()
-            }
 
-        return result.fold(
-            onSuccess = {
-                Result.success(it)
-            },
-            onFailure = {
-                clearCache()
-                Result.failure(it)
-            }
+        // Always emit Disconnected, even if the cleanup chain failed.
+        reportConnectivityStatus(
+            connectivityStatus = VPNManagerConnectionStatus.Disconnected(disconnectReason)
+        )
+
+        // Always clear cache. If cleanup succeeded, surface a clearCache() failure as
+        // the result; if cleanup already failed, propagate the original cleanup failure
+        // and ignore any clearCache() error (best-effort).
+        val clearResult = clearCache()
+        return cleanupResult.fold(
+            onSuccess = { clearResult },
+            onFailure = { Result.failure(it) }
         )
     }
     // endregion

--- a/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/wireguard/StopWireguardConnectionController.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/wireguard/StopWireguardConnectionController.kt
@@ -56,34 +56,36 @@ internal class StopWireguardConnectionController(
 
     // region IStopWireguardConnectionController
     override suspend fun invoke(disconnectReason: DisconnectReason): Result<Unit> {
-        // Best-effort cleanup chain. Any step here may legitimately fail (e.g. when stop
-        // is invoked from the StartConnectionController failure path before a tunnel was
-        // ever created — there will be no byte count job and no tunnel handle to look
-        // up). We must still report the canonical Disconnecting -> Disconnected sequence
-        // regardless of cleanup outcome so clients observing
-        // handleConnectionStatusChange(...) always see a terminal state.
-        val result = reportConnectivityStatus(
-            connectivityStatus = VPNManagerConnectionStatus.Disconnecting
-        ).mapCatching {
-            stopWireguardByteCountJob().getOrThrow()
-        }.mapCatching {
-            getWireguardTunnelHandle().getOrThrow()
-        }.mapCatching {
-            destroyWireguardTunnel(tunnelHandle = it).getOrThrow()
-        }
+        val result = reportConnectivityStatus(connectivityStatus = VPNManagerConnectionStatus.Disconnecting)
+            .mapCatching {
+                stopWireguardByteCountJob().getOrThrow()
+            }
+            .mapCatching {
+                getWireguardTunnelHandle().getOrThrow()
+            }
+            .mapCatching {
+                destroyWireguardTunnel(tunnelHandle = it).getOrThrow()
+            }
+            .mapCatching {
+                reportConnectivityStatus(
+                    connectivityStatus = VPNManagerConnectionStatus.Disconnected(disconnectReason)
+                ).getOrThrow()
+            }
+            .mapCatching {
+                clearCache().getOrThrow()
+            }
 
-        // Always emit Disconnected, even if the cleanup chain failed.
-        reportConnectivityStatus(
-            connectivityStatus = VPNManagerConnectionStatus.Disconnected(disconnectReason)
-        )
-
-        // Always clear cache. If cleanup succeeded, surface a clearCache() failure as
-        // the result; if cleanup already failed, propagate the original cleanup failure
-        // and ignore any clearCache() error (best-effort).
-        val clearResult = clearCache()
         return result.fold(
-            onSuccess = { clearResult },
-            onFailure = { Result.failure(it) }
+            onSuccess = {
+                Result.success(it)
+            },
+            onFailure = {
+                clearCache()
+                reportConnectivityStatus(
+                    connectivityStatus = VPNManagerConnectionStatus.Disconnected(disconnectReason)
+                )
+                Result.failure(it)
+            }
         )
     }
     // endregion

--- a/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/wireguard/StopWireguardConnectionController.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/controllers/wireguard/StopWireguardConnectionController.kt
@@ -62,18 +62,15 @@ internal class StopWireguardConnectionController(
         // up). We must still report the canonical Disconnecting -> Disconnected sequence
         // regardless of cleanup outcome so clients observing
         // handleConnectionStatusChange(...) always see a terminal state.
-        val cleanupResult = reportConnectivityStatus(
+        val result = reportConnectivityStatus(
             connectivityStatus = VPNManagerConnectionStatus.Disconnecting
-        )
-            .mapCatching {
-                stopWireguardByteCountJob().getOrThrow()
-            }
-            .mapCatching {
-                getWireguardTunnelHandle().getOrThrow()
-            }
-            .mapCatching {
-                destroyWireguardTunnel(tunnelHandle = it).getOrThrow()
-            }
+        ).mapCatching {
+            stopWireguardByteCountJob().getOrThrow()
+        }.mapCatching {
+            getWireguardTunnelHandle().getOrThrow()
+        }.mapCatching {
+            destroyWireguardTunnel(tunnelHandle = it).getOrThrow()
+        }
 
         // Always emit Disconnected, even if the cleanup chain failed.
         reportConnectivityStatus(
@@ -84,7 +81,7 @@ internal class StopWireguardConnectionController(
         // the result; if cleanup already failed, propagate the original cleanup failure
         // and ignore any clearCache() error (best-effort).
         val clearResult = clearCache()
-        return cleanupResult.fold(
+        return result.fold(
             onSuccess = { clearResult },
             onFailure = { Result.failure(it) }
         )

--- a/vpnmanager/vpnservicemanager/vpnprotocol/wireguard/build.gradle
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/wireguard/build.gradle
@@ -8,7 +8,6 @@ android {
 
     defaultConfig {
         minSdk rootProject.minSdkVersion
-        targetSdk rootProject.targetSdkVersion
     }
 
     compileOptions {
@@ -47,6 +46,12 @@ android {
         }
     }
     namespace 'com.kape.wireguard'
+    lint {
+        targetSdk 34
+    }
+    testOptions {
+        targetSdk 34
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Previously, when a connect attempt failed (e.g. SSL hostname mismatch), the
inner Start{Wireguard,OpenVpn}ConnectionController.handleFailure emitted
Disconnected before the outer StartConnectionController's cleanup path
emitted its own Disconnecting → Disconnected, producing an out-of-order
sequence visible to clients:

    Connecting → Disconnected → Disconnecting → Disconnected

Changes:
- Inner Start controllers no longer emit Disconnected on failure; they
  clear cache and rethrow so the outer cleanup path owns the terminal
  status sequence.
- Stop{Wireguard,OpenVpn}ConnectionController now always emit Disconnected
  even when the cleanup chain fails partway (e.g. when stop is invoked
  from the Start failure path before native resources were created), so
  clients always observe a terminal state.

Result: handleConnectionStatusChange(...) sees the canonical
Connecting → Disconnecting → Disconnected(reason) on failure.