### PR TITLE
Fixed init connection being blocked

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
     group = "com.kape.android"
-    version = "0.4.9"
+    version = "0.4.10"
 
     apply plugin: "org.jlleitschuh.gradle.ktlint"
 

--- a/vpnmanager/vpnservicemanager/src/main/java/com/kape/vpnservicemanager/domain/controllers/StartConnectionController.kt
+++ b/vpnmanager/vpnservicemanager/src/main/java/com/kape/vpnservicemanager/domain/controllers/StartConnectionController.kt
@@ -68,6 +68,11 @@ internal class StartConnectionController(
     ): Result<VPNServiceServerPeerInformation> {
         return isServiceCleared()
             .mapCatching {
+                stopConnection(DisconnectReason.CLIENT_INITIATED)
+            }.mapCatching {
+                clearCache().getOrThrow()
+            }
+            .mapCatching {
                 setProtocolConfiguration(
                     protocolConfiguration = protocolConfiguration
                 ).getOrFail {
@@ -99,7 +104,10 @@ internal class StartConnectionController(
     }
     // endregion
 
-    private suspend fun handleFailureStoppingConnection(throwable: Throwable, disconnectReason: DisconnectReason) {
+    private suspend fun handleFailureStoppingConnection(
+        throwable: Throwable,
+        disconnectReason: DisconnectReason,
+    ) {
         stopConnection(disconnectReason)
         handleFailure(throwable)
     }

--- a/vpnmanager/vpnservicemanager/src/test/java/com/kape/vpnservicemanager/domain/controllers/StartConnectionControllerTest.kt
+++ b/vpnmanager/vpnservicemanager/src/test/java/com/kape/vpnservicemanager/domain/controllers/StartConnectionControllerTest.kt
@@ -88,7 +88,7 @@ internal class StartConnectionControllerTest {
     }
 
     @Test
-    fun `start successfully should not clear cache`() = runTest {
+    fun `start successfully clears cache exactly once for the pre-stop`() = runTest {
         // given
         val context: Context = ApplicationProvider.getApplicationContext()
         val protocolConfiguration: VPNServiceManagerConfiguration =
@@ -123,7 +123,7 @@ internal class StartConnectionControllerTest {
 
         // then
         assert(result.isSuccess)
-        assert((clearCacheMock as ClearCacheMock).invocationsCounter == 0)
+        assert((clearCacheMock as ClearCacheMock).invocationsCounter == 1)
     }
 
     @Test
@@ -143,6 +143,46 @@ internal class StartConnectionControllerTest {
         val getServerPeerInformationMock: IGetServerPeerInformation =
             GetServerPeerInformationMock(shouldSucceed = true)
         val stopConnectionMock: IStopConnection = StopConnectionMock(shouldSucceed = true)
+        val clearCacheMock: IClearCache = ClearCacheMock()
+        val startConnectionController: IStartConnectionController =
+            GivenController.startConnectionController(
+                context = context,
+                isServiceCleared = isServiceClearedMock,
+                setProtocolConfiguration = setProtocolConfigurationMock,
+                setServerPeerInformation = setServerPeerInformationMock,
+                startConnection = startConnectionMock,
+                startReconnectionHandler = startReconnectionHandlerMock,
+                getServerPeerInformation = getServerPeerInformationMock,
+                stopConnection = stopConnectionMock,
+                clearCache = clearCacheMock
+            )
+
+        // when
+        val result = startConnectionController(protocolConfiguration = protocolConfiguration)
+
+        // then
+        assert(result.isFailure)
+        assert((stopConnectionMock as StopConnectionMock).invocationsCounter == 0)
+        assert((clearCacheMock as ClearCacheMock).invocationsCounter == 0)
+    }
+
+    @Test
+    fun `fail to start when there is a service present and stop fails`() = runTest {
+        // given
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val protocolConfiguration: VPNServiceManagerConfiguration =
+            GivenModel.vpnServiceManagerConfiguration(context = context)
+        val isServiceClearedMock: IIsServiceCleared = IsServiceClearedMock(shouldSucceed = false)
+        val setProtocolConfigurationMock: ISetProtocolConfiguration =
+            SetProtocolConfigurationMock(shouldSucceed = true)
+        val setServerPeerInformationMock: ISetServerPeerInformation =
+            SetServerPeerInformationMock(shouldSucceed = true)
+        val startConnectionMock: IStartConnection = StartConnectionMock(shouldSucceed = true)
+        val startReconnectionHandlerMock: IStartReconnectionHandler =
+            StartReconnectionHandlerMock(shouldSucceed = true)
+        val getServerPeerInformationMock: IGetServerPeerInformation =
+            GetServerPeerInformationMock(shouldSucceed = true)
+        val stopConnectionMock: IStopConnection = StopConnectionMock(shouldSucceed = false)
         val clearCacheMock: IClearCache = ClearCacheMock()
         val startConnectionController: IStartConnectionController =
             GivenController.startConnectionController(
@@ -238,8 +278,8 @@ internal class StartConnectionControllerTest {
 
         // then
         assert(result.isFailure)
-        assert((clearCacheMock as ClearCacheMock).invocationsCounter == 1)
-        assert((stopConnectionMock as StopConnectionMock).invocationsCounter == 0)
+        assert((clearCacheMock as ClearCacheMock).invocationsCounter == 2)
+        assert((stopConnectionMock as StopConnectionMock).invocationsCounter == 1)
     }
 
     @Test
@@ -278,8 +318,8 @@ internal class StartConnectionControllerTest {
 
         // then
         assert(result.isFailure)
-        assert((clearCacheMock as ClearCacheMock).invocationsCounter == 1)
-        assert((stopConnectionMock as StopConnectionMock).invocationsCounter == 1)
+        assert((clearCacheMock as ClearCacheMock).invocationsCounter == 2)
+        assert((stopConnectionMock as StopConnectionMock).invocationsCounter == 2)
     }
 
     @Test
@@ -318,8 +358,8 @@ internal class StartConnectionControllerTest {
 
         // then
         assert(result.isFailure)
-        assert((clearCacheMock as ClearCacheMock).invocationsCounter == 1)
-        assert((stopConnectionMock as StopConnectionMock).invocationsCounter == 1)
+        assert((clearCacheMock as ClearCacheMock).invocationsCounter == 2)
+        assert((stopConnectionMock as StopConnectionMock).invocationsCounter == 2)
     }
 
     @Test
@@ -358,8 +398,8 @@ internal class StartConnectionControllerTest {
 
         // then
         assert(result.isFailure)
-        assert((clearCacheMock as ClearCacheMock).invocationsCounter == 1)
-        assert((stopConnectionMock as StopConnectionMock).invocationsCounter == 1)
+        assert((clearCacheMock as ClearCacheMock).invocationsCounter == 2)
+        assert((stopConnectionMock as StopConnectionMock).invocationsCounter == 2)
     }
 
     @Test
@@ -398,7 +438,7 @@ internal class StartConnectionControllerTest {
 
         // then
         assert(result.isFailure)
-        assert((clearCacheMock as ClearCacheMock).invocationsCounter == 1)
-        assert((stopConnectionMock as StopConnectionMock).invocationsCounter == 1)
+        assert((clearCacheMock as ClearCacheMock).invocationsCounter == 2)
+        assert((stopConnectionMock as StopConnectionMock).invocationsCounter == 2)
     }
 }


### PR DESCRIPTION
With reconnection or rapid quick connect attempts, user gets into a state where `KNOWN_SERVICE_PRESENT` is returned and app becomes unusable. This PR fixes it by stopping cached connection, so that the new one can be initiated.

Also updated version as, ideally, this needs to go with today's PIA release.