### PR TITLE
KM-16892: Parse and return OpenVPN state + new event for OpenVPN output line received

### DIFF
--- a/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/main/java/com/kape/openvpn/domain/usecases/HandleOpenVpnStateOutput.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/main/java/com/kape/openvpn/domain/usecases/HandleOpenVpnStateOutput.kt
@@ -1,6 +1,7 @@
 package com.kape.openvpn.domain.usecases
 
 import com.kape.openvpn.presenters.OpenVpnProcessEventHandler
+import com.kape.openvpn.presenters.OpenVpnState
 
 /*
  *  Copyright (c) 2022 Private Internet Access, Inc.
@@ -22,20 +23,32 @@ import com.kape.openvpn.presenters.OpenVpnProcessEventHandler
 
 internal class HandleOpenVpnStateOutput : IHandleOpenVpnStateOutput {
 
-    private enum class OpenVpnStateLinesOfInterest(val line: String) {
-        CONNECTED("connected"),
-    }
-
     // region IHandleOpenVpnStateOutput
     override fun invoke(
         line: String,
         openVpnProcessEventHandler: OpenVpnProcessEventHandler,
     ): Result<Unit> {
         return runCatching {
-            when {
-                line.contains(OpenVpnStateLinesOfInterest.CONNECTED.line) -> {
-                    openVpnProcessEventHandler.processConnected()
-                }
+            // State lines arrive as: >state:timestamp,state_name,description,...
+            val stateName = line.substringAfter("state:").split(",").getOrNull(1)
+            val state = when (stateName) {
+                "initial" -> OpenVpnState.Initial
+                "connecting" -> OpenVpnState.Connecting
+                "assign_ip" -> OpenVpnState.AssignIp
+                "add_routes" -> OpenVpnState.AddRoutes
+                "connected" -> OpenVpnState.Connected
+                "reconnecting" -> OpenVpnState.Reconnecting
+                "exiting" -> OpenVpnState.Exiting
+                "wait" -> OpenVpnState.Wait
+                "auth_pending" -> OpenVpnState.AuthPending
+                "auth" -> OpenVpnState.Auth
+                "get_config" -> OpenVpnState.GetConfig
+                "resolve" -> OpenVpnState.Resolve
+                "tcp_connect" -> OpenVpnState.TcpConnect
+                else -> null
+            }
+            if (state != null) {
+                openVpnProcessEventHandler.stateUpdated(state)
             }
         }
     }

--- a/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/main/java/com/kape/openvpn/domain/usecases/StartOpenVpnOutputHandler.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/main/java/com/kape/openvpn/domain/usecases/StartOpenVpnOutputHandler.kt
@@ -1,6 +1,5 @@
 package com.kape.openvpn.domain.usecases
 
-import android.util.Log
 import com.kape.openvpn.data.externals.ICache
 import com.kape.openvpn.data.models.OpenVpnServerPeerInformation
 import com.kape.openvpn.presenters.OpenVpnProcessEventHandler
@@ -38,11 +37,9 @@ internal class StartOpenVpnOutputHandler(
     private lateinit var openVpnProcessEventHandler: OpenVpnProcessEventHandler
     private var serverPeerInformation: OpenVpnServerPeerInformation? = null
 
-    companion object {
-        private const val OPENVPN_TAG = "OpenVPN/Process"
-    }
-
-    private enum class OpenVpnProcessCommands(val command: String) {
+    private enum class OpenVpnProcessCommands(
+        val command: String,
+    ) {
         MANAGEMENT_OUTPUT("management:"),
         PASSWORD_OUTPUT("password:"),
         NEED_OK_OUTPUT("need-ok:"),
@@ -65,7 +62,7 @@ internal class StartOpenVpnOutputHandler(
         // The socket reads up to 2048 bytes at a time, so one read may contain multiple
         // newline-separated management messages. Process each line individually.
         line.split("\n").filter { it.isNotBlank() }.forEach { singleLine ->
-            Log.d(OPENVPN_TAG, singleLine)
+            openVpnProcessEventHandler.openVpnProcessOutputLineReceived(singleLine)
             val sanitizedString = singleLine.lowercase()
             when {
                 sanitizedString.contains(OpenVpnProcessCommands.MANAGEMENT_OUTPUT.command) -> {

--- a/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/main/java/com/kape/openvpn/domain/usecases/StartOpenVpnOutputHandler.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/main/java/com/kape/openvpn/domain/usecases/StartOpenVpnOutputHandler.kt
@@ -103,7 +103,10 @@ internal class StartOpenVpnOutputHandler(
                     )
                 }
 
-                sanitizedString.contains(OpenVpnProcessCommands.STATE_OUTPUT.command) -> {
+                // Bare state output (response to `state on all`): timestamp,STATE_NAME,...
+                // Real-time notifications always start with `>`, so digit-starting lines are also state output.
+                sanitizedString.contains(OpenVpnProcessCommands.STATE_OUTPUT.command) ||
+                    sanitizedString.first().isDigit() -> {
                     handleOpenVpnStateOutput(
                         line = sanitizedString,
                         openVpnProcessEventHandler = openVpnProcessEventHandler

--- a/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/main/java/com/kape/openvpn/domain/usecases/StartOpenVpnOutputHandler.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/main/java/com/kape/openvpn/domain/usecases/StartOpenVpnOutputHandler.kt
@@ -62,47 +62,67 @@ internal class StartOpenVpnOutputHandler(
 
     // region IOpenVpnProcessOutputHandler
     override fun output(line: String) {
-        Log.d(OPENVPN_TAG, line)
-        val sanitizedString = line.lowercase()
-        when {
-            sanitizedString.contains(OpenVpnProcessCommands.MANAGEMENT_OUTPUT.command) ->
-                handleOpenVpnManagementOutput(
-                    line = sanitizedString,
-                    openVpnProcessOutputHandler = this
-                )
-            sanitizedString.contains(OpenVpnProcessCommands.PASSWORD_OUTPUT.command) ->
-                handleOpenVpnPasswordOutput(
-                    line = sanitizedString,
-                    openVpnProcessEventHandler = openVpnProcessEventHandler
-                )
-            sanitizedString.contains(OpenVpnProcessCommands.NEED_OK_OUTPUT.command) ->
-                handleOpenVpnNeedOkOutput(
-                    line = sanitizedString,
-                    serverPeerInformation = serverPeerInformation,
-                    openVpnProcessEventHandler = openVpnProcessEventHandler
-                )
-            sanitizedString.contains(OpenVpnProcessCommands.PUSH_OUTPUT.command) ->
-                serverPeerInformation = handleOpenVpnPushOutput(
-                    line = sanitizedString
-                ).getOrNull()
-            sanitizedString.contains(OpenVpnProcessCommands.HOLD_OUTPUT.command) ->
-                handleOpenVpnHoldOutput(
-                    line = sanitizedString
-                )
-            sanitizedString.contains(OpenVpnProcessCommands.STATE_OUTPUT.command) ->
-                handleOpenVpnStateOutput(
-                    line = sanitizedString,
-                    openVpnProcessEventHandler = openVpnProcessEventHandler
-                )
-            sanitizedString.contains(OpenVpnProcessCommands.BYTECOUNT_OUTPUT.command) ->
-                handleOpenVpnByteCountOutput(
-                    line = sanitizedString,
-                    openVpnProcessEventHandler = openVpnProcessEventHandler
-                )
-            sanitizedString.contains(OpenVpnProcessCommands.MTU_TEST_RESULT_OUTPUT.command) ->
-                handleOpenVpnMtuTestResultOutput(
-                    line = sanitizedString
-                )
+        // The socket reads up to 2048 bytes at a time, so one read may contain multiple
+        // newline-separated management messages. Process each line individually.
+        line.split("\n").filter { it.isNotBlank() }.forEach { singleLine ->
+            Log.d(OPENVPN_TAG, singleLine)
+            val sanitizedString = singleLine.lowercase()
+            when {
+                sanitizedString.contains(OpenVpnProcessCommands.MANAGEMENT_OUTPUT.command) -> {
+                    handleOpenVpnManagementOutput(
+                        line = sanitizedString,
+                        openVpnProcessOutputHandler = this
+                    )
+                }
+
+                sanitizedString.contains(OpenVpnProcessCommands.PASSWORD_OUTPUT.command) -> {
+                    handleOpenVpnPasswordOutput(
+                        line = sanitizedString,
+                        openVpnProcessEventHandler = openVpnProcessEventHandler
+                    )
+                }
+
+                sanitizedString.contains(OpenVpnProcessCommands.NEED_OK_OUTPUT.command) -> {
+                    handleOpenVpnNeedOkOutput(
+                        line = sanitizedString,
+                        serverPeerInformation = serverPeerInformation,
+                        openVpnProcessEventHandler = openVpnProcessEventHandler
+                    )
+                }
+
+                sanitizedString.contains(OpenVpnProcessCommands.PUSH_OUTPUT.command) -> {
+                    serverPeerInformation =
+                        handleOpenVpnPushOutput(
+                            line = sanitizedString
+                        ).getOrNull()
+                }
+
+                sanitizedString.contains(OpenVpnProcessCommands.HOLD_OUTPUT.command) -> {
+                    handleOpenVpnHoldOutput(
+                        line = sanitizedString
+                    )
+                }
+
+                sanitizedString.contains(OpenVpnProcessCommands.STATE_OUTPUT.command) -> {
+                    handleOpenVpnStateOutput(
+                        line = sanitizedString,
+                        openVpnProcessEventHandler = openVpnProcessEventHandler
+                    )
+                }
+
+                sanitizedString.contains(OpenVpnProcessCommands.BYTECOUNT_OUTPUT.command) -> {
+                    handleOpenVpnByteCountOutput(
+                        line = sanitizedString,
+                        openVpnProcessEventHandler = openVpnProcessEventHandler
+                    )
+                }
+
+                sanitizedString.contains(OpenVpnProcessCommands.MTU_TEST_RESULT_OUTPUT.command) -> {
+                    handleOpenVpnMtuTestResultOutput(
+                        line = sanitizedString
+                    )
+                }
+            }
         }
     }
     // endregion

--- a/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/main/java/com/kape/openvpn/presenters/OpenVpnAPI.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/main/java/com/kape/openvpn/presenters/OpenVpnAPI.kt
@@ -101,6 +101,13 @@ public interface OpenVpnProcessEventHandler {
      * @return `Result<Unit>`
      */
     fun processByteCountReceived(tx: Long, rx: Long): Result<Unit>
+
+    /**
+     * @param line `String`.
+     *
+     * @return `Result<Unit>`
+     */
+    fun openVpnProcessOutputLineReceived(line: String): Result<Unit>
 }
 
 /**

--- a/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/main/java/com/kape/openvpn/presenters/OpenVpnAPI.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/main/java/com/kape/openvpn/presenters/OpenVpnAPI.kt
@@ -44,6 +44,26 @@ public interface OpenVpnAPI {
 }
 
 /**
+ * Sealed class representing the possible OpenVPN connection states reported via the management
+ * interface.
+ */
+public sealed class OpenVpnState {
+    public data object Initial : OpenVpnState()
+    public data object Connecting : OpenVpnState()
+    public data object AssignIp : OpenVpnState()
+    public data object AddRoutes : OpenVpnState()
+    public data object Connected : OpenVpnState()
+    public data object Reconnecting : OpenVpnState()
+    public data object Exiting : OpenVpnState()
+    public data object Wait : OpenVpnState()
+    public data object Auth : OpenVpnState()
+    public data object GetConfig : OpenVpnState()
+    public data object Resolve : OpenVpnState()
+    public data object TcpConnect : OpenVpnState()
+    public data object AuthPending : OpenVpnState()
+}
+
+/**
  * Interface defining the handler of openvpn's process relevant events.
  */
 public interface OpenVpnProcessEventHandler {
@@ -68,9 +88,11 @@ public interface OpenVpnProcessEventHandler {
     fun getUserCredentials(): Result<OpenVpnUserCredentials>
 
     /**
+     * @param state `OpenVpnState`.
+     *
      * @return `Result<Unit>`
      */
-    fun processConnected(): Result<Unit>
+    fun stateUpdated(state: OpenVpnState): Result<Unit>
 
     /**
      * @param tx `Long`.

--- a/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/test/java/com/kape/openvpn/testutils/mocks/OpenVpnProcessEventHandlerMock.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/test/java/com/kape/openvpn/testutils/mocks/OpenVpnProcessEventHandlerMock.kt
@@ -39,4 +39,7 @@ internal class OpenVpnProcessEventHandlerMock : OpenVpnProcessEventHandler {
 
     override fun processByteCountReceived(tx: Long, rx: Long): Result<Unit> =
         Result.success(Unit)
+
+    override fun openVpnProcessOutputLineReceived(line: String): Result<Unit> =
+        Result.success(Unit)
 }

--- a/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/test/java/com/kape/openvpn/testutils/mocks/OpenVpnProcessEventHandlerMock.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/openvpn/src/test/java/com/kape/openvpn/testutils/mocks/OpenVpnProcessEventHandlerMock.kt
@@ -2,6 +2,7 @@ package com.kape.openvpn.testutils.mocks
 
 import com.kape.openvpn.data.models.OpenVpnServerPeerInformation
 import com.kape.openvpn.presenters.OpenVpnProcessEventHandler
+import com.kape.openvpn.presenters.OpenVpnState
 import com.kape.openvpn.presenters.OpenVpnUserCredentials
 
 /*
@@ -33,7 +34,7 @@ internal class OpenVpnProcessEventHandlerMock : OpenVpnProcessEventHandler {
     override fun getUserCredentials(): Result<OpenVpnUserCredentials> =
         Result.success(OpenVpnUserCredentials("username", "password"))
 
-    override fun processConnected(): Result<Unit> =
+    override fun stateUpdated(state: OpenVpnState): Result<Unit> =
         Result.success(Unit)
 
     override fun processByteCountReceived(tx: Long, rx: Long): Result<Unit> =

--- a/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/usecases/openvpn/StartOpenVpnEventHandler.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/usecases/openvpn/StartOpenVpnEventHandler.kt
@@ -1,5 +1,6 @@
 package com.kape.vpnprotocol.domain.usecases.openvpn
 
+import android.util.Log
 import com.kape.openvpn.data.models.OpenVpnServerPeerInformation
 import com.kape.openvpn.presenters.OpenVpnProcessEventHandler
 import com.kape.openvpn.presenters.OpenVpnState
@@ -94,5 +95,14 @@ internal class StartOpenVpnEventHandler(
 
     override fun processByteCountReceived(tx: Long, rx: Long): Result<Unit> =
         cacheProtocol.reportByteCount(tx = tx, rx = rx)
+
+    override fun openVpnProcessOutputLineReceived(line: String): Result<Unit> {
+        Log.d(OPENVPN_TAG, line)
+        return Result.success(Unit)
+    }
     // endregion
+
+    companion object {
+        private const val OPENVPN_TAG = "OpenVPN/Process"
+    }
 }

--- a/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/usecases/openvpn/StartOpenVpnEventHandler.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/src/main/java/com/kape/vpnprotocol/domain/usecases/openvpn/StartOpenVpnEventHandler.kt
@@ -2,6 +2,7 @@ package com.kape.vpnprotocol.domain.usecases.openvpn
 
 import com.kape.openvpn.data.models.OpenVpnServerPeerInformation
 import com.kape.openvpn.presenters.OpenVpnProcessEventHandler
+import com.kape.openvpn.presenters.OpenVpnState
 import com.kape.openvpn.presenters.OpenVpnUserCredentials
 import com.kape.vpnprotocol.data.externals.common.ICacheProtocol
 import com.kape.vpnprotocol.data.externals.common.ICacheService
@@ -78,7 +79,11 @@ internal class StartOpenVpnEventHandler(
         )
     }
 
-    override fun processConnected(): Result<Unit> {
+    override fun stateUpdated(state: OpenVpnState): Result<Unit> {
+        if (state != OpenVpnState.Connected) {
+            return Result.success(Unit)
+        }
+
         val deferred = cacheOpenVpn.getOpenVpnProcessConnectedDeferrable().getOrElse {
             return Result.failure(it)
         }

--- a/vpnmanager/vpnservicemanager/vpnprotocol/src/test/java/com/kape/vpnprotocol/testutils/mocks/OpenVpnProcessEventHandlerMock.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/src/test/java/com/kape/vpnprotocol/testutils/mocks/OpenVpnProcessEventHandlerMock.kt
@@ -46,5 +46,9 @@ internal class OpenVpnProcessEventHandlerMock : OpenVpnProcessEventHandler {
     override fun processByteCountReceived(tx: Long, rx: Long): Result<Unit> {
         return Result.success(Unit)
     }
+
+    override fun openVpnProcessOutputLineReceived(line: String): Result<Unit> {
+        return Result.success(Unit)
+    }
     // endregion
 }

--- a/vpnmanager/vpnservicemanager/vpnprotocol/src/test/java/com/kape/vpnprotocol/testutils/mocks/OpenVpnProcessEventHandlerMock.kt
+++ b/vpnmanager/vpnservicemanager/vpnprotocol/src/test/java/com/kape/vpnprotocol/testutils/mocks/OpenVpnProcessEventHandlerMock.kt
@@ -2,6 +2,7 @@ package com.kape.vpnprotocol.testutils.mocks
 
 import com.kape.openvpn.data.models.OpenVpnServerPeerInformation
 import com.kape.openvpn.presenters.OpenVpnProcessEventHandler
+import com.kape.openvpn.presenters.OpenVpnState
 import com.kape.openvpn.presenters.OpenVpnUserCredentials
 import com.kape.vpnprotocol.testutils.GivenModel
 
@@ -38,7 +39,7 @@ internal class OpenVpnProcessEventHandlerMock : OpenVpnProcessEventHandler {
         return Result.success(GivenModel.openVpnUserCredentials())
     }
 
-    override fun processConnected(): Result<Unit> {
+    override fun stateUpdated(state: OpenVpnState): Result<Unit> {
         return Result.success(Unit)
     }
 


### PR DESCRIPTION
**Motivation**
The existing `OpenVpnProcessEventHandler` doesn't tell the VPN Manager that the connection state may have been updated as only the "Connected" state via `processConnected()` is submitted.
This means in scenario where OpenVPN gives up on connecting and returns the "Exiting" state or might be stuck in "Reconnecting" state, the VPN manager is not notified and can't take actions such as trying to reconnect to a different endpoint or show a connection error. Replacing `processConnected()` to a new `stateUpdated(state: OpenVpnState)` allows for more flexibility for the VPN manager.

Similarly, a new `openVpnProcessOutputLineReceived()` that is called for every output line we receive from the OpenVPN process allows the VPN manager to be more flexible.

**Changes**
- Fixed some OpenVPN process output not being processed when multiple messages are submitted in the same output line
- Replaced `processConnected()` from `OpenVpnProcessEventHandler` to a new `stateUpdated(state: OpenVpnState)` which is called whenever we receive a new "STATE" from OpenVPN
- Added `openVpnProcessOutputLineReceived()` to `OpenVpnProcessEventHandler` which is called for every output line
- Move Logcat logging of the OpenVPN process output out of the OpenVPN module using `openVpnProcessOutputLineReceived()`

**Testing**
This was NOT tested on this repository testapp as I'm not too sure how to get OpenVPN connection working on it. This was instead tested using another project which uses the `openvpn` module directly.

Confirmed the following states are received: 
- `Connecting`
- `Wait`
- `Auth`
- `GetConfig`
- `AssignIp`
- `Connected`
- `Reconnecting`
- `Exiting`
  - caveat: calling `openVpnApi.stop()` doesn't seem to trigger `Exiting`. This state seems to only be returned when OpenVPN decides to stop the connection on its own

Confirmed that OpenVPN process output lines are being sent to `openVpnProcessOutputLineReceived()`